### PR TITLE
feat: add project automation workflow

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,0 +1,58 @@
+name: Project Automation
+
+on:
+  create:
+  repository_dispatch:
+  issues:
+    types: [opened]
+
+jobs:
+  setup-project:
+    if: github.event_name == 'create' || github.event_name == 'repository_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create project and default columns
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: project } = await github.rest.projects.createForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: '📋 Project Tasks'
+            });
+            const columns = ['To Do', 'In Progress', 'Done'];
+            for (const name of columns) {
+              await github.rest.projects.createColumn({ project_id: project.id, name });
+            }
+
+  add-issue:
+    if: github.event_name == 'issues' && github.event.action == 'opened'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add issue to project
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const projectName = '📋 Project Tasks';
+            const { data: projects } = await github.rest.projects.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            const project = projects.find(p => p.name === projectName);
+            if (!project) {
+              core.setFailed(`Project ${projectName} not found`);
+              return;
+            }
+            const { data: columns } = await github.rest.projects.listColumns({ project_id: project.id });
+            const column = columns.find(c => c.name === 'To Do');
+            if (!column) {
+              core.setFailed('To Do column not found');
+              return;
+            }
+            await github.rest.projects.createCard({
+              column_id: column.id,
+              content_id: context.payload.issue.id,
+              content_type: 'Issue'
+            });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,6 @@ Example: `npm run dev` then open the printed local URL.
 ## Security & Configuration Tips
 - Do not commit secrets. Vite env vars should use `VITE_` prefix and live in local `.env` files ignored by Git.
 - Review `docs/architecture.md` for high‑level design before larger changes.
+
+## Automation
+- `.github/workflows/project-automation.yml` creates the "📋 Project Tasks" project and auto-adds new issues to its "To Do" column.

--- a/TODO.md
+++ b/TODO.md
@@ -39,6 +39,7 @@ CLI版「満腹じゃんけん」を、React + Vite を用いたモダンなWeb�
 - [ ] ゲームコアロジックのユニットテストを拡充
 - [ ] UIコンポーネントのテスト（Storybook / Vitest）
 - [ ] GitHub Actionsを利用したCI（ビルド、テスト、Lint）の設定
+- [x] GitHub Projectの自動化ワークフロー追加
 
 ## 将来案 (Future)
 - [ ] オンライン対戦モード (WebSocket)

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+### Added
+- GitHub Actions workflow `project-automation.yml` to create a project board and add new issues as cards.

--- a/readme.md
+++ b/readme.md
@@ -91,3 +91,6 @@ MIT License
 - `--underline-color`: `cyan|magenta|green|yellow|blue|white`
 - `--foods-csv`: 食べ物CSVのパス（`hand,name,kcal[,points]`）
 - `--foods-mode`: `extend` | `replace`（CSVの適用方法）
+
+## プロジェクト管理 / Project Management
+このリポジトリでは GitHub Actions によってプロジェクトボードを自動生成します。新規リポジトリ作成時に "📋 Project Tasks" プロジェクトと "To Do", "In Progress", "Done" のカラムが作成され、Issue が作成されると "To Do" カラムへカードとして追加されます。


### PR DESCRIPTION
## Summary
- automate project board creation and issue card placement
- document workflow in README and AGENTS
- record changes in changelog and TODO

## Testing
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e05012568832a8c5e2e8754e8f6f2